### PR TITLE
Fix bug in bugfix

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -921,7 +921,7 @@ socket.on('disconnect', function () {
     for (var i = 0; i < userIDs.length; i++) {
         var userID = userIDs[i];
         var user = ONLINE.users[userID];
-        if (user.cursor) {
+        if (user.cursor && user.cursor.parentNode) {
             user.cursor.parentNode.removeChild(user.cursor);
         }
     }


### PR DESCRIPTION
Disconnecting still threw an error because the cursor might not have a parentNode.